### PR TITLE
hotfix/allow-secure-cookies

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
     cookies().set({
       name: "futile-refresh-token",
       value: refreshToken,
-      secure: false, //process.env.NODE_ENV === "production",
+      secure: process.env.NODE_ENV === "production",
     })
     return NextResponse.json({
       status: 200,

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: Request) {
     cookies().set({
       name: "futile-refresh-token",
       value: refreshToken,
-      secure: false, //process.env.NODE_ENV === "production",
+      secure: process.env.NODE_ENV === "production",
     })
 
     return NextResponse.json(


### PR DESCRIPTION
reintroduce `process.env.NODE_ENV === 'production'` as conditional for `secure:` options on setting cookies and iron-session options